### PR TITLE
Add quiz progress indicators and scoring

### DIFF
--- a/face-morph-quiz/index.html
+++ b/face-morph-quiz/index.html
@@ -14,6 +14,11 @@
       <p class="lede">Drag the slider to reveal the two faces in the morph, then guess who is hidden. Each round mixes two of the illustrated portraits.</p>
     </header>
 
+    <div class="status" aria-live="polite" role="status">
+      <p class="pill" id="progress"></p>
+      <p class="pill pill-quiet" id="score"></p>
+    </div>
+
     <section class="morph-card">
       <div class="face-stack" aria-live="polite">
         <img id="base-face" class="face-layer" alt="Base face">

--- a/face-morph-quiz/script.js
+++ b/face-morph-quiz/script.js
@@ -56,12 +56,25 @@ const promptEl = document.getElementById("prompt");
 const optionsEl = document.getElementById("options");
 const feedbackEl = document.getElementById("feedback");
 const nextBtn = document.getElementById("next-btn");
+const progressEl = document.getElementById("progress");
+const scoreEl = document.getElementById("score");
 
 let currentIndex = 0;
+let score = 0;
+let hasAnswered = false;
 
 function setMorphOpacity(value) {
   sliderValue.textContent = value;
   blendFace.style.opacity = value / 100;
+}
+
+function updateStatus() {
+  const round = Math.min(currentIndex + 1, questions.length);
+  progressEl.textContent =
+    currentIndex >= questions.length
+      ? "All morphs complete"
+      : `Round ${round} of ${questions.length}`;
+  scoreEl.textContent = `Score: ${score}/${questions.length}`;
 }
 
 function shuffle(array) {
@@ -74,6 +87,7 @@ function shuffle(array) {
 }
 
 function renderQuestion() {
+  hasAnswered = false;
   const question = questions[currentIndex];
   promptEl.textContent = question.prompt;
 
@@ -84,6 +98,7 @@ function renderQuestion() {
 
   setMorphOpacity(50);
   slider.value = 50;
+  slider.disabled = false;
   feedbackEl.textContent = "";
   feedbackEl.className = "feedback";
 
@@ -97,9 +112,15 @@ function renderQuestion() {
     button.addEventListener("click", () => handleGuess(button, label));
     optionsEl.appendChild(button);
   });
+
+  nextBtn.disabled = true;
+  nextBtn.textContent = currentIndex === questions.length - 1 ? "Finish quiz" : "Next round";
+  updateStatus();
 }
 
 function handleGuess(button, guess) {
+  if (hasAnswered) return;
+  hasAnswered = true;
   const question = questions[currentIndex];
   const buttons = Array.from(optionsEl.querySelectorAll("button"));
   buttons.forEach((b) => {
@@ -108,6 +129,7 @@ function handleGuess(button, guess) {
 
   const isCorrect = guess === question.answer;
   if (isCorrect) {
+    score += 1;
     feedbackEl.textContent = `Nice! The morph hides ${question.answer}.`;
     feedbackEl.className = "feedback correct";
     button.classList.add("correct");
@@ -120,11 +142,43 @@ function handleGuess(button, guess) {
       correctButton.classList.add("correct");
     }
   }
+
+  nextBtn.disabled = false;
+  updateStatus();
 }
 
 function nextQuestion() {
-  currentIndex = (currentIndex + 1) % questions.length;
+  if (currentIndex >= questions.length) {
+    startQuiz();
+    return;
+  }
+
+  if (currentIndex === questions.length - 1) {
+    showSummary();
+    return;
+  }
+
+  currentIndex += 1;
   renderQuestion();
+}
+
+function startQuiz() {
+  currentIndex = 0;
+  score = 0;
+  renderQuestion();
+  feedbackEl.textContent = "";
+}
+
+function showSummary() {
+  slider.disabled = true;
+  feedbackEl.textContent = `Quiz complete! You scored ${score} out of ${questions.length}.`;
+  feedbackEl.className = "feedback correct";
+  promptEl.textContent = "Ready for another round? Hit restart to play again.";
+  optionsEl.innerHTML = "";
+  nextBtn.textContent = "Play again";
+  nextBtn.disabled = false;
+  currentIndex = questions.length;
+  updateStatus();
 }
 
 slider.addEventListener("input", (event) => {

--- a/face-morph-quiz/styles.css
+++ b/face-morph-quiz/styles.css
@@ -46,6 +46,29 @@ header .lede {
   max-width: 60ch;
 }
 
+.status {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  flex-wrap: wrap;
+}
+
+.pill {
+  margin: 0;
+  padding: 8px 12px;
+  background: rgba(43, 125, 233, 0.1);
+  border: 1px solid rgba(43, 125, 233, 0.2);
+  color: var(--accent-strong);
+  border-radius: 999px;
+  font-weight: 700;
+}
+
+.pill-quiet {
+  background: rgba(92, 105, 120, 0.08);
+  border-color: rgba(92, 105, 120, 0.15);
+  color: var(--muted);
+}
+
 .eyebrow {
   margin: 0;
   letter-spacing: 0.2em;
@@ -218,6 +241,12 @@ input[type="range"] {
 
 .next:active {
   transform: translateY(0);
+}
+
+.next:disabled {
+  cursor: not-allowed;
+  opacity: 0.7;
+  box-shadow: none;
 }
 
 @media (max-width: 640px) {


### PR DESCRIPTION
## Summary
- display round progress and cumulative score above the morph card
- add quiz flow improvements that disable the slider and buttons until a guess is made and show a completion state with restart
- refresh styles for the new status pills and disabled next button

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694580d35ff883329f290a74f735d4ee)